### PR TITLE
[RFC] high-level dispatching transform pipeline

### DIFF
--- a/torchvision/transforms/_core.py
+++ b/torchvision/transforms/_core.py
@@ -24,7 +24,7 @@ def query_sample(sample: Any, fn: Callable[[Any], Optional[T]]) -> Iterator[T]:
             yield result
 
 
-class TransformDispatch:
+class JointTransform:
     def __init__(self, transform):
         self.transform = transform
         self.transform.set_reset_auto(False)

--- a/torchvision/transforms/_core.py
+++ b/torchvision/transforms/_core.py
@@ -29,10 +29,13 @@ class TransformDispatch:
         self.transform = transform
         self.transform.set_reset_auto(False)
 
-    def __call__(self, input_dict):
-        input_dict = {key: self.transform(value) for key, value in input_dict.items()}
+    def __call__(self, inputs):
+        if isinstance(inputs, collections.abc.Mapping):
+            inputs = {key: self.transform(value) for key, value in inputs.items()}
+        elif isinstance(inputs, collections.abc.Sequence):
+            inputs = tuple(self.transform(input) for input in inputs)
         self.transform.wipeout_()
-        return input_dict
+        return inputs
 
 
 class Transform(nn.Module):
@@ -121,9 +124,9 @@ class Compose(nn.Module):
         super().__init__()
         self._transforms = transforms
 
-    def forward(self, *inputs: Any) -> Any:
+    def forward(self, inputs):
         for transform in self._transforms:
-            inputs = transform(*inputs)
+            inputs = transform(inputs)
         return inputs
 
     def set_reset_auto(self, mode=True):

--- a/torchvision/transforms/_core.py
+++ b/torchvision/transforms/_core.py
@@ -9,7 +9,7 @@ from torch import nn
 
 from torchvision.features import BoundingBox, Feature, Image
 
-__all__ = ["Transform", "Compose", "query_sample"]
+__all__ = ["Transform", "Compose", "query_sample", "TransformDispatch"]
 
 T = TypeVar("T")
 
@@ -24,10 +24,10 @@ def query_sample(sample: Any, fn: Callable[[Any], Optional[T]]) -> Iterator[T]:
             yield result
 
 
-class TransformDispatch():
-    def __init__(self, transforms):
-        self.transforms = transforms
-        self.transforms.set_reset_auto(False)
+class TransformDispatch:
+    def __init__(self, transform):
+        self.transform = transform
+        self.transform.set_reset_auto(False)
 
     def __call__(self, input_dict):
         input_dict = {key: self.transform(value) for key, value in input_dict.items()}
@@ -50,7 +50,7 @@ class Transform(nn.Module):
 
     def set_reset_auto(self, mode=True):
         self.reset_auto = mode
-    
+
     def wipeout_(self):
         self.initialized = False
         self.saved_params = None
@@ -132,7 +132,7 @@ class Compose(nn.Module):
                 warn(f"transform of type {t} cannot be set to reset_auto={mode} as it is not a Transform instance")
             else:
                 t.set_reset_auto(mode)
-    
+
     def wipeout_(self):
         for t in self._transforms:
             if not isinstance(t, (Compose, Transform)):

--- a/torchvision/transforms/_core.py
+++ b/torchvision/transforms/_core.py
@@ -2,6 +2,7 @@ import collections.abc
 import inspect
 import re
 from typing import Any, Callable, Dict, Iterator, Optional, Type, TypeVar
+from warnings import warn
 
 import torch
 from torch import nn
@@ -23,6 +24,17 @@ def query_sample(sample: Any, fn: Callable[[Any], Optional[T]]) -> Iterator[T]:
             yield result
 
 
+class TransformDispatch():
+    def __init__(cls, transforms):
+        cls.transforms = transforms
+        cls.transforms.set_reset_auto(False)
+
+    def __call__(cls, input_dict):
+        input_dict = {key: cls.transform(value) for key, value in input_dict.items()}
+        cls.transform.wipeout_()
+        return input_dict
+
+
 class Transform(nn.Module):
     _KNOWN_FEATURE_TYPES = {
         "_".join([part.lower() for part in re.findall("[A-Z][^A-Z]*", feature_type.__name__)]): feature_type
@@ -30,9 +42,18 @@ class Transform(nn.Module):
     }
 
     def __init_subclass__(cls, *, auto_register: bool = True):
+        cls.initialized = False
+        cls.reset_auto = True
         cls._feature_transforms: Dict[Type[Feature], Callable] = {}
         if auto_register:
             cls._auto_register()
+
+    def set_reset_auto(cls, mode=True):
+        cls.reset_auto = mode
+    
+    def wipeout_(cls):
+        cls.initialized = False
+        cls.saved_params = None
 
     @classmethod
     def _auto_register(cls) -> None:
@@ -78,35 +99,43 @@ class Transform(nn.Module):
         feature_transform = cls._feature_transforms[feature_type]
         return feature_transform(input, **params)
 
-    def get_params(self, sample: Any) -> Dict[str, Any]:
+    def get_params(cls, sample: Any) -> Dict[str, Any]:
         return dict()
 
-    def forward(self, *inputs: Any, params: Optional[Dict[str, Any]] = None) -> Any:
-        sample = inputs if len(inputs) > 1 else inputs[0]
-        if params is None:
-            params = self.get_params(sample)
+    def forward(cls, input: torch.Tensor) -> torch.Tensor:
+        if not cls.initialized:
+            cls.saved_params = cls.get_params(input)
 
-        def apply(sample: Any):
-            if isinstance(sample, collections.abc.Sequence):
-                return [apply(item) for item in sample]
-            elif isinstance(sample, collections.abc.Mapping):
-                return {name: apply(item) for name, item in sample.items()}
-            else:
-                feature_type = type(sample)
-                if not (feature_type is torch.Tensor or feature_type in self._feature_transforms):
-                    return sample
+        feature_type = type(input)
+        if not (feature_type is torch.Tensor or feature_type in cls._feature_transforms):
+            return input
 
-                return self.apply(sample, **params)
-
-        return apply(sample)
+        output = cls.apply(input, **cls.saved_params)
+        if cls.reset_auto:
+            cls.wipeout_()
+        return output
 
 
 class Compose(nn.Module):
-    def __init__(self, *transforms: Transform) -> None:
+    def __init__(cls, *transforms: Transform) -> None:
         super().__init__()
-        self._transforms = transforms
+        cls._transforms = transforms
 
-    def forward(self, *inputs: Any) -> Any:
-        for transform in self._transforms:
+    def forward(cls, *inputs: Any) -> Any:
+        for transform in cls._transforms:
             inputs = transform(*inputs)
         return inputs
+
+    def set_reset_auto(cls, mode=True):
+        for t in cls._transforms:
+            if not isinstance(t, (Compose, Transform)):
+                warn(f"transform of type {t} cannot be set to reset_auto={mode} as it is not a Transform instance")
+            else:
+                t.set_reset_auto(mode)
+    
+    def wipeout_(cls):
+        for t in cls._transforms:
+            if not isinstance(t, (Compose, Transform)):
+                warn(f"transform of type {t} cannot be wiped out as it is not a Transform instance")
+            else:
+                t.wipeout_()

--- a/torchvision/transforms/_core.py
+++ b/torchvision/transforms/_core.py
@@ -44,9 +44,12 @@ class Transform(nn.Module):
         for feature_type in (Image, BoundingBox)
     }
 
+    def __init__(self):
+        self.initialized = False
+        self.reset_auto = True
+        super().__init__()
+
     def __init_subclass__(cls, *, auto_register: bool = True):
-        cls.initialized = False
-        cls.reset_auto = True
         cls._feature_transforms: Dict[Type[Feature], Callable] = {}
         if auto_register:
             cls._auto_register()

--- a/torchvision/transforms/_core.py
+++ b/torchvision/transforms/_core.py
@@ -41,12 +41,12 @@ class Transform(nn.Module):
         for feature_type in (Image, BoundingBox)
     }
 
-    def __init_subclass__(self, *, auto_register: bool = True):
-        self.initialized = False
-        self.reset_auto = True
-        self._feature_transforms: Dict[Type[Feature], Callable] = {}
+    def __init_subclass__(cls, *, auto_register: bool = True):
+        cls.initialized = False
+        cls.reset_auto = True
+        cls._feature_transforms: Dict[Type[Feature], Callable] = {}
         if auto_register:
-            self._auto_register()
+            cls._auto_register()
 
     def set_reset_auto(self, mode=True):
         self.reset_auto = mode

--- a/torchvision/transforms/_core.py
+++ b/torchvision/transforms/_core.py
@@ -9,7 +9,7 @@ from torch import nn
 
 from torchvision.features import BoundingBox, Feature, Image
 
-__all__ = ["Transform", "Compose", "query_sample", "TransformDispatch"]
+__all__ = ["Transform", "Compose", "query_sample", "JointTransform"]
 
 T = TypeVar("T")
 

--- a/transforms_poc.py
+++ b/transforms_poc.py
@@ -10,24 +10,24 @@ bbox = BoundingBox(torch.tensor([7, 3, 9, 8]), image_size=image.image_size, form
 bbox_e = BoundingBox(torch.tensor([1, 3, 3, 8]), image_size=image_e.image_size, format="xyxy")
 
 transform = transforms.HorizontalFlip()
-functional_transform = transforms.HorizontalFlip.apply
 
 torch.testing.assert_close(transform(image), image_e)
-torch.testing.assert_close(functional_transform(image), image_e)
 
 torch.testing.assert_close(transform(bbox).convert("xyxy"), bbox_e)
-torch.testing.assert_close(functional_transform(bbox).convert("xyxy"), bbox_e)
 
-sample_a = transform(dict(image=image, bbox=bbox))
+dispatch_transform = transforms.TransformDispatch(transform)
+
+sample_a = dispatch_transform(dict(image=image, bbox=bbox))
 torch.testing.assert_close(sample_a["image"], image_e)
 torch.testing.assert_close(sample_a["bbox"].convert("xyxy"), bbox_e)
 
-image_a, bbox_a = transform(image, bbox)
-torch.testing.assert_close(image_a, image_e)
-torch.testing.assert_close(bbox_a.convert("xyxy"), bbox_e)
+# FIXME: tuple dispatch is not yet supported
+# image_a, bbox_a = dispatch_transform(image, bbox)
+# torch.testing.assert_close(image_a, image_e)
+# torch.testing.assert_close(bbox_a.convert("xyxy"), bbox_e)
 
-composed_transform = transforms.Compose(transform, transform)
-
-image_a, bbox_a = composed_transform(image, bbox)
-torch.testing.assert_close(image_a, image)
-torch.testing.assert_close(bbox_a.convert("xyxy"), bbox)
+# FIXME: composed transforms are not yet supported
+# composed_transform = transforms.Compose(transform, transform)
+#
+# image_a, bbox_a = composed_transform(image)
+# torch.testing.assert_close(image_a, image)

--- a/transforms_poc.py
+++ b/transforms_poc.py
@@ -21,13 +21,12 @@ sample_a = dispatch_transform(dict(image=image, bbox=bbox))
 torch.testing.assert_close(sample_a["image"], image_e)
 torch.testing.assert_close(sample_a["bbox"].convert("xyxy"), bbox_e)
 
-# FIXME: tuple dispatch is not yet supported
-# image_a, bbox_a = dispatch_transform(image, bbox)
-# torch.testing.assert_close(image_a, image_e)
-# torch.testing.assert_close(bbox_a.convert("xyxy"), bbox_e)
+image_a, bbox_a = dispatch_transform((image, bbox))
+torch.testing.assert_close(image_a, image_e)
+torch.testing.assert_close(bbox_a.convert("xyxy"), bbox_e)
 
-# FIXME: composed transforms are not yet supported
-# composed_transform = transforms.Compose(transform, transform)
-#
-# image_a, bbox_a = composed_transform(image)
-# torch.testing.assert_close(image_a, image)
+composed_transform = transforms.Compose(transform, transform)
+dispatch_transform = transforms.TransformDispatch(composed_transform)
+sample_a = dispatch_transform(dict(image=image, bbox=bbox))
+image_a = composed_transform(image)
+torch.testing.assert_close(image_a, image)

--- a/transforms_poc.py
+++ b/transforms_poc.py
@@ -15,7 +15,7 @@ torch.testing.assert_close(transform(image), image_e)
 
 torch.testing.assert_close(transform(bbox).convert("xyxy"), bbox_e)
 
-dispatch_transform = transforms.TransformDispatch(transform)
+dispatch_transform = transforms.JointTransform(transform)
 
 sample_a = dispatch_transform(dict(image=image, bbox=bbox))
 torch.testing.assert_close(sample_a["image"], image_e)
@@ -26,7 +26,7 @@ torch.testing.assert_close(image_a, image_e)
 torch.testing.assert_close(bbox_a.convert("xyxy"), bbox_e)
 
 composed_transform = transforms.Compose(transform, transform)
-dispatch_transform = transforms.TransformDispatch(composed_transform)
+dispatch_transform = transforms.JointTransform(composed_transform)
 sample_a = dispatch_transform(dict(image=image, bbox=bbox))
 image_a = composed_transform(image)
 torch.testing.assert_close(image_a, image)


### PR DESCRIPTION
I propose a high-level dispatching of the transfom, such that `transform.forward` only sees tensor(-like) inputs.
The `TransformDispatch` class should be used as a wrapper for a transform (or a composition of transforms). Provided that those are Transform instances, then TransformDispatch will take care of keeping the random parameters in memory for the time that the transform is applied. 
The main advantage i see is code clarity: the transform forward methods only sees a single data type, whereas other implementation have tedious routing scripts and methods. They also can receive and return a wide variety of datatypes, which -- I think -- is not very neat.
I have not proposed a method to wrap the transforms in TransformDispatch in a training script -- i'm open to suggestions on that one. I guess it will strongly depend on what the vision datasets will look like in the future.